### PR TITLE
Update Gradle Wrapper from 8.11.1 to 8.12

### DIFF
--- a/demo/src/test/kotlin/io/github/gmazzo/gradle/aar2jar/demo/CameraHelper.kt
+++ b/demo/src/test/kotlin/io/github/gmazzo/gradle/aar2jar/demo/CameraHelper.kt
@@ -1,7 +1,6 @@
 package io.github.gmazzo.gradle.aar2jar.demo
 
 import android.app.Application
-import android.content.Context
 import androidx.camera.view.PreviewView
 
 object CameraHelper {

--- a/demo/src/testFixtures/kotlin/io/github/gmazzo/gradle/aar2jar/demo/BrowserHelper.kt
+++ b/demo/src/testFixtures/kotlin/io/github/gmazzo/gradle/aar2jar/demo/BrowserHelper.kt
@@ -1,7 +1,5 @@
 package io.github.gmazzo.gradle.aar2jar.demo
 
-import androidx.browser.browseractions.BrowserActionItem
-import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.TrustedWebUtils
 
 object BrowserHelper {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionSha256Sum=7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/plugin/src/test/kotlin/io/github/gmazzo/gradle/aar2jar/AAR2JARPluginTest.kt
+++ b/plugin/src/test/kotlin/io/github/gmazzo/gradle/aar2jar/AAR2JARPluginTest.kt
@@ -1,5 +1,14 @@
 package io.github.gmazzo.gradle.aar2jar
 
+import org.gradle.api.Action
+import org.gradle.api.problems.ProblemSpec
+import org.gradle.api.problems.internal.AdditionalDataBuilderFactory
+import org.gradle.api.problems.internal.InternalProblemReporter
+import org.gradle.api.problems.internal.InternalProblemSpec
+import org.gradle.api.problems.internal.InternalProblems
+import org.gradle.api.problems.internal.Problem
+import org.gradle.api.problems.internal.ProblemsProgressEventEmitterHolder
+import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.get
 import org.gradle.testfixtures.ProjectBuilder
@@ -19,6 +28,8 @@ class AAR2JARPluginTest {
     @ParameterizedTest(name = "{0}")
     @CsvSource("runtimeClasspath", "compileClasspath")
     fun `can resolve AAR dependencies`(configuration: String): Unit = with(ProjectBuilder.builder().build()) {
+        gradleIssue31862Workaround()
+
         apply(plugin = "java")
         apply(plugin = "io.github.gmazzo.aar2jar")
 
@@ -34,5 +45,42 @@ class AAR2JARPluginTest {
             resolvedArtifacts,
         )
     }
+
+    // TODO workaround for https://github.com/gradle/gradle/issues/31862
+    private fun gradleIssue31862Workaround() = ProblemsProgressEventEmitterHolder.init(object : InternalProblems {
+
+        override fun getInternalReporter() = object : InternalProblemReporter {
+
+            override fun create(action: Action<InternalProblemSpec?>): Problem {
+                TODO("Not yet implemented")
+            }
+
+            override fun report(problem: Problem) {
+            }
+
+            override fun report(problems: Collection<Problem?>) {
+            }
+
+            override fun report(problem: Problem, id: OperationIdentifier) {
+            }
+
+            override fun throwing(exception: Throwable, problems: Collection<Problem?>) =
+                error("Exception: $exception")
+
+            override fun reporting(spec: Action<ProblemSpec?>) {
+            }
+
+            override fun throwing(spec: Action<ProblemSpec?>) =
+                error("Exception: $spec")
+
+        }
+
+        override fun getAdditionalDataBuilderFactory(): AdditionalDataBuilderFactory {
+            TODO("Not yet implemented")
+        }
+
+        override fun getReporter() = getInternalReporter()
+
+    })
 
 }


### PR DESCRIPTION
Update Gradle Wrapper from 8.11.1 to 8.12.

Read the release notes: https://docs.gradle.org/8.12/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `8.12`
- Distribution (-bin) zip checksum: `7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03`
- Wrapper JAR Checksum: `2db75c40782f5e8ba1fc278a5574bab070adccb2d21ca5a6e5ed840888448046`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>