### PR TITLE
Exclude kotlin-stdlib from plugin dependencies

### DIFF
--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,0 +1,3 @@
+# Omit automatic compile dependency on kotlin-stdlib.
+# https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library

```diff
diff --color=auto -r 0.1.0-SNAPSHOT-before/maven-metadata-local.xml 0.1.0-SNAPSHOT-after/maven-metadata-local.xml
6c6
<     <lastUpdated>20250407041522</lastUpdated>
---
>     <lastUpdated>20250407041657</lastUpdated>
12c12
<         <extension>jar</extension>
---
>         <extension>module</extension>
14c14
<         <updated>20250407041522</updated>
---
>         <updated>20250407041657</updated>
20c20
<         <updated>20250407041522</updated>
---
>         <updated>20250407041657</updated>
25c25
<         <updated>20250407041522</updated>
---
>         <updated>20250407041657</updated>
28c28,29
<         <extension>module</extension>
---
>         <classifier>javadoc</classifier>
>         <extension>jar</extension>
30c31
<         <updated>20250407041522</updated>
---
>         <updated>20250407041657</updated>
33d33
<         <classifier>javadoc</classifier>
36c36
<         <updated>20250407041522</updated>
---
>         <updated>20250407041657</updated>
Binary files 0.1.0-SNAPSHOT-before/plugin-0.1.0-SNAPSHOT-javadoc.jar and 0.1.0-SNAPSHOT-after/plugin-0.1.0-SNAPSHOT-javadoc.jar differ
diff --color=auto -r 0.1.0-SNAPSHOT-before/plugin-0.1.0-SNAPSHOT.module 0.1.0-SNAPSHOT-after/plugin-0.1.0-SNAPSHOT.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.20"
<           }
<         }
<       ],
60,68d50
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.1.20"
<           }
<         }
<       ],
93,97c75,79
<           "size": 409935,
<           "sha512": "d46258b4121fa8639cbd1f679d767b3a56d424b7f520c162a1da447517ca1cf7db4d208bc94d8138505016af92a4bc50f6dbc88333128c925cb3518d3e63b64c",
<           "sha256": "1521102e95e50931b89fde99c8e2676ce67191b5510def386740e3f3d5e0ea1c",
<           "sha1": "1e1bf200304152c257d41f1680f09cc302fa890b",
<           "md5": "e862aa0bdf27d2638112b7222fdbe791"
---
>           "size": 409843,
>           "sha512": "ea7d979f03bbdd739ef0eee1d36b6baa0c08e8a16a3dcfef038c783e3fcf5f2d40937b29d8c327fb6966cd193a9410c411c71573cef1926f4994cce8e31db5ab",
>           "sha256": "075c0388d9d2acf92f42ec6c3c3ad535553a0e575676abd3450697ca7086edf6",
>           "sha1": "f792b54cd6351ca0b6824642111f2d51340aa160",
>           "md5": "fcefcb01fa3ad60fa58e4ecd94c059b8"
diff --color=auto -r 0.1.0-SNAPSHOT-before/plugin-0.1.0-SNAPSHOT.pom 0.1.0-SNAPSHOT-after/plugin-0.1.0-SNAPSHOT.pom
33,40d32
<   <dependencies>
<     <dependency>
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.1.20</version>
<       <scope>compile</scope>
<     </dependency>
<   </dependencies>
```